### PR TITLE
Add access control

### DIFF
--- a/docs/example-contravider-config.toml
+++ b/docs/example-contravider-config.toml
@@ -10,3 +10,5 @@
 #host = "localhost"
 #port = 8083
 #root = "web"
+username = "alice"
+password = "secret"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,9 +35,11 @@ type Log struct {
 
 // Web are the config options for the web interface.
 type Web struct {
-	Host string `toml:"host"`
-	Port int    `toml:"port"`
-	Root string `toml:"root"`
+	Host     string `toml:"host"`
+	Port     int    `toml:"port"`
+	Root     string `toml:"root"`
+	Username string `toml:"username"`
+	Password string `toml:"password"`
 }
 
 // Config are all the configuration options.


### PR DESCRIPTION
This PR adds access control for the two paths: 
- `/.well-known/csaf/amber/`
- `/.well-known/csaf/red/`
- 
Both directories are now wrapped with Basic-Auth middleware; only authenticated users can access their contents, while all other routes remain publicly reachable.